### PR TITLE
Update Threema to 1.2.49 and FreeDesktopSDK 25.08

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+threema-web-electron/
+.flatpak-builder/
+builddir/

--- a/0002-add-debian-aarch64-build.patch
+++ b/0002-add-debian-aarch64-build.patch
@@ -85,18 +85,18 @@ index 5b17471..9bc22bc 100644
  
  main();
 diff --git a/tools/run-dist-electron.js b/tools/run-dist-electron.js
-index 12e3ab1..e135d17 100644
+index f4c4ca3..11c368c 100644
 --- a/tools/run-dist-electron.js
 +++ b/tools/run-dist-electron.js
-@@ -10,6 +10,8 @@ const common = require("./packaging/common");
- const makeUniversalApp = require("@electron/universal");
+@@ -15,6 +15,8 @@ import {
+ import {signWindowsBinaryOrPackage} from "./signing/sign-windows.js";
  
  const DEV_ENV = process.env.DEV_ENV;
 +const ARCH_OUTNAME = process.env.ARCH_OUTNAME;
 +const ARCH_ELECTRON = process.env.ARCH_ELECTRON;
+ const log = debug("dist-electron");
  
  let packageName = "";
- 
 -- 
 2.35.1
 

--- a/0002-add-debian-aarch64-build.patch
+++ b/0002-add-debian-aarch64-build.patch
@@ -10,10 +10,10 @@ Subject: Add support for Debian arm64 build
  3 files changed, 18 insertions(+), 6 deletions(-)
 
 diff --git a/app/package.json b/app/package.json
-index 15695fe..6d0c79d 100644
+index dc9e5d1..45d331a 100644
 --- a/app/package.json
 +++ b/app/package.json
-@@ -174,7 +174,8 @@
+@@ -176,7 +176,8 @@
            "executableName": "threema-web",
            "platform": "linux",
            "arch": [
@@ -22,8 +22,8 @@ index 15695fe..6d0c79d 100644
 +            "arm64"
            ],
            "icons": {
-             "128x128": "app/assets/icons/png/consumer-128x128.png",
-@@ -190,7 +191,8 @@
+             "48x48": "app/assets/icons/png/consumer-48x48.png",
+@@ -194,7 +195,8 @@
            "executableName": "threema-work-web",
            "platform": "linux",
            "arch": [
@@ -32,9 +32,9 @@ index 15695fe..6d0c79d 100644
 +            "arm64"
            ],
            "icons": {
-             "128x128": "app/assets/icons/png/work-128x128.png",
-@@ -206,7 +208,8 @@
-           "executableName": "threema-red-web",
+             "48x48": "app/assets/icons/png/work-48x48.png",
+@@ -212,7 +214,8 @@
+           "executableName": "threema-blue-web",
            "platform": "linux",
            "arch": [
 -            "x64"
@@ -42,13 +42,13 @@ index 15695fe..6d0c79d 100644
 +            "arm64"
            ],
            "icons": {
-             "128x128": "app/assets/icons/png/red-128x128.png",
+             "48x48": "app/assets/icons/png/blue-48x48.png",
 diff --git a/tools/packaging/package-deb.js b/tools/packaging/package-deb.js
-index 5b17471..9bc22bc 100644
+index e077352..7d243cd 100644
 --- a/tools/packaging/package-deb.js
 +++ b/tools/packaging/package-deb.js
-@@ -14,11 +14,17 @@ async function main() {
-     executableName += `-${common.getChannelName()}`;
+@@ -19,11 +19,17 @@ async function main() {
+     executableName += `-${getChannelName()}`;
    }
  
 -  console.log(`Creating package for ${appDirName} (this may take a while)`);
@@ -67,16 +67,16 @@ index 5b17471..9bc22bc 100644
      dest: "app/build/dist-electron/installers",
      name: appDirName,
      bin: executableName,
-@@ -27,7 +33,7 @@ async function main() {
+@@ -32,7 +38,7 @@ async function main() {
      genericName: "Threema Desktop Client",
      maintainer: "Threema GmbH <help@threema.ch>",
      icon: configs["linux-deb"][myArgs[0]]["icons"],
 -    arch: "amd64",
 +    arch: "${ARCH_OUTNAME}",
      homepage: "https://threema.ch",
-     categories: ["Social Media"],
+     categories: ["Network", "InstantMessaging", "Chat"],
      description: "Desktop client for Threema (requires the mobile app)",
-@@ -44,6 +50,7 @@ async function main() {
+@@ -49,6 +55,7 @@ async function main() {
      console.error(err, err.stack);
      process.exit(1);
    }
@@ -98,5 +98,5 @@ index f4c4ca3..11c368c 100644
  
  let packageName = "";
 -- 
-2.35.1
+2.47.1
 

--- a/0003-Metainfo.xml-Fix-release-info.patch
+++ b/0003-Metainfo.xml-Fix-release-info.patch
@@ -1,8 +1,6 @@
-diff --git a/ch.threema.threema-web-desktop.metainfo.xml b/ch.threema.threema-web-desktop.metainfo.xml
-index 67cf902..c82fd86 100644
---- a/ch.threema.threema-web-desktop.metainfo.xml
-+++ b/ch.threema.threema-web-desktop.metainfo.xml
-@@ -4,8 +4,10 @@
+--- a/ch.threema.threema-web-desktop.metainfo.xml	2026-02-15 12:49:27.573285090 +0100
++++ b/ch.threema.threema-web-desktop.metainfo.xml	2026-02-15 12:49:27.580891505 +0100
+@@ -4,18 +4,21 @@
    <id>ch.threema.threema-web-desktop</id>
    <name>Threema</name>
    <project_license>AGPL-3.0</project_license>
@@ -15,7 +13,10 @@ index 67cf902..c82fd86 100644
    <url type="homepage">https://threema.ch/</url>
    <url type="help">https://threema.ch/support</url>
    <url type="contact">https://threema.ch/en/request/default?i_have_read_the_faq=1</url>
-@@ -15,7 +17,7 @@
++  <url type="vcs-browser">https://github.com/threema-ch/threema-web-electron</url>
+   <description>
+     <p>This is a COMMUNITY-MAINTAINED UNOFFICIAL Flatpak package.</p>
+     <p>Threema for desktop is a desktop client for Threema, a privacy-focused end-to-end encrypted mobile messenger hosted and developed in Switzerland. With Threema for desktop, you can use Threema on your desktop without compromising security.</p>
      <p>Threema for desktop currently requires an active connection to Threema installed on a smartphone. The next major update of the desktop app will not only introduce a completely redesigned user interface, it will also be based on a totally new architecture. Thanks to multi-device functionality, version 2.0 will no longer require an active connection to your mobile device.</p>
    </description>
    <screenshots>
@@ -24,7 +25,7 @@ index 67cf902..c82fd86 100644
        <caption>The Threema for desktop main window</caption>
        <image type="source">https://raw.githubusercontent.com/threema-ch/threema-web-electron/develop/assets/threema-desktop-screenshot1.png</image>
      </screenshot>
-@@ -178,7 +180,7 @@
+@@ -210,7 +213,7 @@
          <ul>
            <li>macOS: Improved support for Apple processors</li>
            <li>Linux: Fixed an issue where the app icon was missing in some cases</li>

--- a/0004-Disable-full-Electron-packaging.patch
+++ b/0004-Disable-full-Electron-packaging.patch
@@ -1,28 +1,31 @@
 From ff1276a3a31c025578e0c2133ac094fcd4ec03bb Mon Sep 17 00:00:00 2001
 From: Leonard Janis Robert Koenig <ljrk@ljrk.org>
 Date: Fri, 27 Dec 2024 00:46:26 +0100
-Subject: [PATCH] Ignore errors for full Electron packaging
+Subject: [PATCH] Use pre-cached Electron zip for offline Flatpak builds
 
-This fails within CI because of some dependencies that
-flatpak-node-generator doesn't pick up(?):
-
-> Prepare package for linux-deb consumer
-> Could not create package because of an error: RequestError: getaddrinfo EAI_AGAIN github.com
-
-Sometimes(?) this builds successfully anyway because of a
-race condition(?) in the wrapping script and actually the
-built Electron asar package(?). So let's just ignore any errors
-in this step and hope for the best :D
+@electron/packager normally downloads Electron from GitHub, which fails
+in the Flatpak build sandbox (no network access). Use the electronZipDir
+option to point it at the pre-downloaded Electron zip from
+flatpak-node-generator's cache. Also keep the error-ignoring fallback
+just in case.
 ---
- tools/run-dist-electron.js | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
+ tools/run-dist-electron.js | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/tools/run-dist-electron.js b/tools/run-dist-electron.js
-index 267f7bf..d0cd57a 100644
+index f4c4ca3..7c47123 100644
 --- a/tools/run-dist-electron.js
 +++ b/tools/run-dist-electron.js
-@@ -282,8 +282,10 @@ async function main() {
-     await package(pkg, os, flavour);
+@@ -101,6 +101,7 @@ async function buildPackage(pkg, os, flavour) {
+     prune: true,
+     overwrite: true,
+     asar: true,
++    electronZipDir: process.env.XDG_CACHE_HOME ? `${process.env.XDG_CACHE_HOME}/electron` : undefined,
+     arch: osConfig["arch"],
+     platform: osConfig["platform"],
+     icon: osConfig["iconPath"],
+@@ -281,7 +282,9 @@ async function main() {
+     await buildPackage(pkg, os, flavour);
    } catch (error) {
      console.log(`Could not create package because of an error: ${error}`);
 -    process.exit(1);
@@ -32,7 +35,6 @@ index 267f7bf..d0cd57a 100644
 +
  }
  
- if (require.main === module) {
 -- 
 2.47.1
 

--- a/0004-Disable-full-Electron-packaging.patch
+++ b/0004-Disable-full-Electron-packaging.patch
@@ -16,7 +16,7 @@ diff --git a/tools/run-dist-electron.js b/tools/run-dist-electron.js
 index f4c4ca3..7c47123 100644
 --- a/tools/run-dist-electron.js
 +++ b/tools/run-dist-electron.js
-@@ -101,6 +101,7 @@ async function buildPackage(pkg, os, flavour) {
+@@ -103,6 +103,7 @@ async function buildPackage(pkg, os, flavour) {
      prune: true,
      overwrite: true,
      asar: true,
@@ -24,7 +24,7 @@ index f4c4ca3..7c47123 100644
      arch: osConfig["arch"],
      platform: osConfig["platform"],
      icon: osConfig["iconPath"],
-@@ -281,7 +282,9 @@ async function main() {
+@@ -283,7 +284,9 @@ async function main() {
      await buildPackage(pkg, os, flavour);
    } catch (error) {
      console.log(`Could not create package because of an error: ${error}`);

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ specific.
 ## Packaging / Release Update Checklist
 
 * [x] Make sure that `THREEMA_WEB_VERSION` environment variable matches the
-  `version` field in the `package.json` of the `app/dependencies/threema-web`
-  submodule (as described in the README).
+  `version` field in the `package.json` of the `app/dependencies/threema-web` of the `threema-web-electron` submodule (as described in the README).
+  It can also be inherited from `threemaWebVersion` of `app/package.json`.
 * [x] Since the app uses Electron we use the official Flatpak Electron template.
   However, as described in detail here [2] we need to pre-fetch all dependencies,
   as node may not connect to the Internet within the build step.
@@ -26,6 +26,8 @@ specific.
       flatpak-node-generator npm -r --electron-node-headers \
               package-lock.json
 
+  Copy the generated `generated-sources.json` to your own `ch.threema.threema-web-desktop` branch.
+  
   We also need to add the electron headers, otherwise the postinstall of electron
   will try to fetch additional dependencies in the build step as well.
 

--- a/ch.threema.threema-web-desktop.yml
+++ b/ch.threema.threema-web-desktop.yml
@@ -40,9 +40,10 @@ modules:
         npm_config_nodedir: /usr/lib/sdk/node20
         npm_config_offline: 'true'
     sources:
+      # Threema Web Electron release 1.2.49
       - type: git
         url: https://github.com/threema-ch/threema-web-electron.git
-        commit: 8d8eacad7dc8cb7f419ac2279f80fe8754d5fa17
+        commit: 6fc9e3d7065e3f5b977c8668e6dfb524ee2c1450
       # Threema requested that the package must be declared as community maintained
       - type: patch
         path: 0001-note-unofficial-flatpak.patch

--- a/ch.threema.threema-web-desktop.yml
+++ b/ch.threema.threema-web-desktop.yml
@@ -1,9 +1,9 @@
 app-id: ch.threema.threema-web-desktop
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node22
 command: run.sh

--- a/ch.threema.threema-web-desktop.yml
+++ b/ch.threema.threema-web-desktop.yml
@@ -5,7 +5,7 @@ sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
 base-version: '24.08'
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node20
+  - org.freedesktop.Sdk.Extension.node22
 command: run.sh
 separate-locales: false
 finish-args:
@@ -15,7 +15,7 @@ finish-args:
   - --share=network
   - --filesystem=xdg-download
 build-options:
-  append-path: /usr/lib/sdk/node20/bin
+  append-path: /usr/lib/sdk/node22/bin
   env:
     NPM_CONFIG_LOGLEVEL: info
     # Must be set according to upstream: https://github.com/threema-ch/threema-web-electron/pull/4#issuecomment-995968724
@@ -37,7 +37,7 @@ modules:
       env:
         XDG_CACHE_HOME: /run/build/threema-web-desktop/flatpak-node/cache
         npm_config_cache: /run/build/threema-web-desktop/flatpak-node/npm-cache
-        npm_config_nodedir: /usr/lib/sdk/node20
+        npm_config_nodedir: /usr/lib/sdk/node22
         npm_config_offline: 'true'
     sources:
       # Threema Web Electron release 1.2.49

--- a/ch.threema.threema-web-desktop.yml
+++ b/ch.threema.threema-web-desktop.yml
@@ -10,7 +10,8 @@ command: run.sh
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   - --filesystem=xdg-download
@@ -62,7 +63,7 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
-          - zypak-wrapper.sh /app/main/threema-web "$@"
+          - zypak-wrapper.sh /app/main/threema-web --ozone-platform-hint=auto "$@"
       - type: file
         path: ch.threema.threema-web-desktop.desktop
     build-commands:


### PR DESCRIPTION
Updated the Threema app (including needed Node.JS update) and the FreeDesktop SDK.

Needed to fix a build error, due to renaming of a function in the upstream project.