### PR TITLE
Fix #21 MESA driver launch

### DIFF
--- a/ch.threema.threema-web-desktop.yml
+++ b/ch.threema.threema-web-desktop.yml
@@ -15,6 +15,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --filesystem=xdg-download
+  - --device=dri
 build-options:
   append-path: /usr/lib/sdk/node22/bin
   env:


### PR DESCRIPTION
This PR aims to fix #21, since MESA can't do OpenGL rendering without it.